### PR TITLE
第6章 ユーザー定義関数

### DIFF
--- a/chapter6/args_default.php
+++ b/chapter6/args_default.php
@@ -1,0 +1,11 @@
+<?php
+function getTriangleArea(float $base = 5, float $height = 1): float {
+    return $base * $height /2;
+}
+
+$area = getTriangleArea();
+print "三角形の面積は {$area} です！！";
+$area = getTriangleArea(10);
+print "三角形の面積は {$area} です！！";
+$area = getTriangleArea(40, 100);
+print "三角形の面積は {$area} です！！";

--- a/chapter6/function1.php
+++ b/chapter6/function1.php
@@ -1,0 +1,8 @@
+<?php
+
+function getTriangleArea($base, $height) {
+    return $base * $height / 2;
+}
+
+$area = getTriangleArea(8, 10);
+print "三角形の面積は $area です！";

--- a/chapter6/function2.php
+++ b/chapter6/function2.php
@@ -1,0 +1,8 @@
+<?php
+
+function getTriangleArea(float $base, float $height): float {
+    return $base * $height / 2;
+}
+
+$area = getTriangleArea(8, 10);
+print "三角形の面積は {$area} です！";

--- a/chapter6/include.php
+++ b/chapter6/include.php
@@ -3,6 +3,3 @@
 function getTriangleArea(float $base, float $height): float {
     return $base * $height / 2;
 }
-
-$area = getTriangleArea(8, 10);
-print "三角形の面積は {$area} です！";

--- a/chapter6/ref.php
+++ b/chapter6/ref.php
@@ -1,0 +1,9 @@
+<?php
+function increment(int &$num): int {
+    $num++;
+    return $num;
+}
+
+$value = 10;
+print increment($value);
+print $value;

--- a/chapter6/require_once.php
+++ b/chapter6/require_once.php
@@ -1,0 +1,5 @@
+<?php
+require_once './include.php';
+
+$area = getTriangleArea(8, 10);
+print "三角形の面積は {$area} です！";

--- a/chapter6/scope.php
+++ b/chapter6/scope.php
@@ -1,0 +1,10 @@
+<?php
+
+$x = 10;
+
+function checkScope(): int {
+    return ++$x;
+}
+
+print checkScope();
+print $x;

--- a/chapter6/scope.php
+++ b/chapter6/scope.php
@@ -3,6 +3,7 @@
 $x = 10;
 
 function checkScope(): int {
+    global $x;
     return ++$x;
 }
 

--- a/chapter6/static1.php
+++ b/chapter6/static1.php
@@ -1,0 +1,11 @@
+<?php
+$x = 0;
+
+function checkStatic(): int {
+    static $x = 0;
+    return ++$x;
+}
+
+print checkStatic();
+print checkStatic();
+print $x;


### PR DESCRIPTION
## 知見
- PHP7では引数/戻り値には積極的に型を明示する！！
     - PHP5のタイプヒンティングでは、`戻り値では型宣言できない` `引数で型宣言できるのは配列/オブジェクトだけ` だった(int, floatは指定できない)
- `: float` で戻り値の型も宣言できるのか〜
- declare(strict_types=1) で厳密な型チェックになる
     - しかし関数の呼び出し側で宣言する必要がある
- require: 致命的なエラー, include: 警告
- 関数はコンパイル時に読み込まれているのであって実行時ではない
- &$変数 で参照渡しになる